### PR TITLE
docs: fix simple typo, useage -> usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Django 1.6+ (如果在Django中使用)
 
 # Index
 
-[Python Useage](#python-usage)
+[Python Usage](#python-usage)
 
-[Django useage](#django-usage)
+[Django usage](#django-usage)
 
 
 # Python Usage


### PR DESCRIPTION
There is a small typo in README.md.

Should read `usage` rather than `useage`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md